### PR TITLE
Adds glossary for 'a build'

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,5 +1,9 @@
 == Glossary of Gradle terms
 
+[[a-build]]
+=== A build
+A 'build' is the aggregate of the atomic pieces of work performed by Gradle. A build is made up of <<project,projects>> and those projects have a collection of tasks. A build usually has an outcome of SUCCESS or FAILURE. You can run a build using the `gradle` or `gradlew` commands. 
+
 [[build-script]]
 === Build script
 A `build.gradle` script. The existence of a build script, along with an entry in the


### PR DESCRIPTION
Explains what "a build" is. When people ask 
"did you run a build"
"which build did you run"
"is your gradle build working"


The glossary could now do with explainers for
- tasks
- gradle wrapper

perhaps also

- outcomes (task/build outcomes)

I can do PR's for task / gradle wrapper, just testing the water with this small PR first :-)